### PR TITLE
Load workspace does not work properly 

### DIFF
--- a/widget.cpp
+++ b/widget.cpp
@@ -185,7 +185,7 @@ void SigGen::Panel::updateMode(int index)
   this->update_state(RT::State::MODIFY);
 }
 
-void SigGen::Panel::refresh() {}
+// void SigGen::Panel::refresh() {}
 
 void SigGen::Panel::customizeGUI()
 {

--- a/widget.hpp
+++ b/widget.hpp
@@ -111,7 +111,7 @@ public:
   void customizeGUI();
 
 public slots:
-  void refresh() override;
+  // void refresh() override;
 
 private:
   // QT components


### PR DESCRIPTION
The load workspace does not work properly when the refresh method is overridden but not implemented, so the refresh method removed

What does it mean?

GUI doesn't reflect the new parameter values since there is no mechanism to reflect when the refresh method is overridden but not implemented. Not that load workspace calls the `this->getPanel()->refresh();`